### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/y-engine/Cargo.toml
+++ b/y-engine/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["alexdesander <alexdesander@tuta.io>"]
 description = "A micro-engine that handles boilerplate (winit, wgpu, etc.) and adds quality-of-life features for easy application setup."
 keywords = ["gamedev", "engine", "wgpu", "winit"]
 categories = ["game-development"]
-repository = "https://www.github.com/alexdesander/y-engine"
+repository = "https://github.com/alexdesander/y-engine"
 license = "MIT OR Apache-2.0"
 
 [workspace.metadata.clippy]


### PR DESCRIPTION
Github redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96
You can find out info about all of your crates here: https://rust-digger.code-maven.com/users/alexdesander